### PR TITLE
Fix release-please publish condition

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,7 @@ jobs:
 
   publish:
     needs: release-please
-    if: ${{ needs.release-please.outputs.releases_created }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Fixes the publish job condition to only run when releases are actually created.

## Problem
The publish job was running on every commit to main because the condition  treats any non-empty string as truthy.

## Solution
Changed to explicit string comparison: 

## Test plan
- [x] Verified the condition logic
- [x] This prevents unnecessary publishing attempts on regular commits
- [x] Will only run when release-please actually creates a release

Fixes the issue seen in: https://github.com/petersalomonsen/near-rpc-typescript/actions/runs/16345520184/job/46178102675