### PR TITLE
fix: correct test and coverage commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ To run all tests for both packages, use the following command from the root of t
 
 ```bash
 # Run all tests in watch mode
-pnpm -r run test:watch
+pnpm -r test:watch
 
-# Run all tests once
-pnpm -r test
+# Run all tests once (avoiding watch mode)
+pnpm test
 ```
 
 _Note: The root `pnpm test` command is an alias for `pnpm -r test`._
@@ -126,11 +126,11 @@ _Note: The root `pnpm test` command is an alias for `pnpm -r test`._
 To run tests for a specific package, use the `--filter` flag with the package name:
 
 ```bash
-# Run tests for the types package in watch mode
+# Run tests for the types package once
 pnpm --filter @near-js/jsonrpc-types test
 
-# Run tests for the client package once
-pnpm --filter @near-js/jsonrpc-client test -- run
+# Run tests for the client package in watch mode
+pnpm --filter @near-js/jsonrpc-client test:watch
 ```
 
 ### Coverage
@@ -139,10 +139,10 @@ To generate a coverage report, add the `--coverage` flag to the test command:
 
 ```bash
 # Generate coverage for all packages
-pnpm -r test -- run --coverage
+pnpm -r test:coverage
 
 # Generate coverage for a specific package
-pnpm --filter @near-js/jsonrpc-client test -- run --coverage
+pnpm --filter @near-js/jsonrpc-client test:coverage
 ```
 
 ## 🤖 Automation


### PR DESCRIPTION
## Summary
- Fixed incorrect coverage command syntax that was causing test failures
- Updated test command descriptions for clarity
- Ensured all commands in README are working correctly

## Test plan
- [x] Verified `pnpm -r test:coverage` works correctly
- [x] Verified `pnpm --filter @near-js/jsonrpc-client test:coverage` works correctly  
- [x] Tested all other pnpm commands in README
- [x] Confirmed test commands now properly distinguish between watch mode and single run

The previous `pnpm -r test -- run --coverage` syntax was incorrectly passing "run" as a test file pattern to vitest, causing it to look for test files matching "run" and fail.

🤖 Generated with [Claude Code](https://claude.ai/code)