### PR TITLE
test: drop tree-shaken status request schema assertion

### DIFF
--- a/examples/tree-shaking/tree-shaking.test.ts
+++ b/examples/tree-shaking/tree-shaking.test.ts
@@ -123,8 +123,11 @@ describe('Tree-shaking Bundle Tests', () => {
     const bundlePath = path.join(distDir, 'bundle.js');
     const content = fs.readFileSync(bundlePath, 'utf-8');
 
-    // main.ts uses status, so it should contain Status schemas
-    expect(content).toContain('RpcStatusRequestSchema');
+    // main.ts uses status, so it should contain the Status response schema.
+    // Note: the status *request* schema is `z.null()` (status takes no params)
+    // and main.ts calls status() without params, so its trivial request
+    // validation is dead code that rollup tree-shakes away. Only the response
+    // schema remains as proof that a used function's schema is bundled.
     expect(content).toContain('RpcStatusResponseSchema');
 
     // Should NOT contain schemas for unused functions


### PR DESCRIPTION
## Problem

`cd examples/tree-shaking && pnpm test` fails:

```
FAIL tree-shaking.test.ts > regular bundle should only contain schemas for used functions
AssertionError: expected '// src/client.ts\nfunction camelToSna…' to contain 'RpcStatusRequestSchema'
```

Reproduces on a clean `main` — independent of the pnpm 11 / prebuild fix.

## Root cause

The NEAR OpenAPI spec defines `RpcStatusRequest` as `{ enum: [null], nullable: true }`, so the generated schema is:

```ts
export const RpcStatusRequestSchema = () => z.null();
```

The generated validated `status()` guards request validation with `if (params !== undefined)`. `main.ts` calls `status(defaultClient)` **without params**, so that block is dead code, and the schema it references is the trivial `z.null()`. Under the example's `treeshake: { moduleSideEffects: false }`, rollup removes the whole request-validation block — so `RpcStatusRequestSchema` never appears in `bundle.js`. The non-trivial **response** schema (`RpcStatusResponseSchema`) is still emitted.

## Fix

The test's intent — *a used function's schema is bundled, unused functions' schemas are not* — is still fully covered by the `RpcStatusResponseSchema` assertion plus the unused-schema (`Block*`/`Query*`/`Chunk*`/`VALIDATION_SCHEMA_MAP`) absence checks. Drop the stale request-schema expectation and document why.

## Validation

- [x] `cd examples/tree-shaking && pnpm test` — 8 passed (was 1 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)